### PR TITLE
focus search field on ctrl+f

### DIFF
--- a/main.js
+++ b/main.js
@@ -617,6 +617,14 @@ searchFieldEl.addEventListener('keydown', e => {
   }
 });
 
+addEventListener('keydown', e => {
+  if ((e.ctrlKey || e.metaKey) && e.key == 'f' && document.activeElement != searchFieldEl) {
+    e.preventDefault();
+    searchFieldEl.focus();
+    searchFieldEl.select();
+  }
+});
+
 function notifyError(f) {
   try {
     f();


### PR DESCRIPTION
Now you don't have to click search bar to search.
If you press Ctrl+f twice, it will work normally.